### PR TITLE
fixed potential naming conflicts with Google Firebase sdk

### DIFF
--- a/SimpleFirebaseUnity/SimpleDataSnapshot.cs
+++ b/SimpleFirebaseUnity/SimpleDataSnapshot.cs
@@ -37,14 +37,14 @@ namespace SimpleFirebaseUnity
 {
 	using MiniJSON;
 
-    public class DataSnapshot
+    public class SimpleDataSnapshot
     {
         protected object val_obj;
         protected Dictionary<string, object> val_dict;
         protected List<string> keys;
         protected string json;
 
-        protected DataSnapshot()
+        protected SimpleDataSnapshot()
         {
             val_dict = null;
             val_obj = null;
@@ -56,7 +56,7 @@ namespace SimpleFirebaseUnity
         /// Creates snapshot from Json string 
         /// </summary>
         /// <param name="json">Json string</param>
-        public DataSnapshot(string _json = "")
+        public SimpleDataSnapshot(string _json = "")
         {
 			object obj = (_json != null && _json.Length > 0)?Json.Deserialize(_json):null;
 

--- a/SimpleFirebaseUnity/SimpleFirebase.cs
+++ b/SimpleFirebaseUnity/SimpleFirebase.cs
@@ -41,27 +41,27 @@ namespace SimpleFirebaseUnity
 {
     using MiniJSON;
     [Serializable]
-    public class Firebase
+    public class SimpleFirebase
     {
         const string SERVER_VALUE_TIMESTAMP = "{\".sv\": \"timestamp\"}";
 
-        public Action<Firebase, DataSnapshot> OnGetSuccess;
-        public Action<Firebase, FirebaseError> OnGetFailed;
+        public Action<SimpleFirebase, SimpleDataSnapshot> OnGetSuccess;
+        public Action<SimpleFirebase, SimpleFirebaseError> OnGetFailed;
 
-        public Action<Firebase, DataSnapshot> OnSetSuccess;
-        public Action<Firebase, FirebaseError> OnSetFailed;
+        public Action<SimpleFirebase, SimpleDataSnapshot> OnSetSuccess;
+        public Action<SimpleFirebase, SimpleFirebaseError> OnSetFailed;
 
-        public Action<Firebase, DataSnapshot> OnUpdateSuccess;
-        public Action<Firebase, FirebaseError> OnUpdateFailed;
+        public Action<SimpleFirebase, SimpleDataSnapshot> OnUpdateSuccess;
+        public Action<SimpleFirebase, SimpleFirebaseError> OnUpdateFailed;
 
-        public Action<Firebase, DataSnapshot> OnPushSuccess;
-        public Action<Firebase, FirebaseError> OnPushFailed;
+        public Action<SimpleFirebase, SimpleDataSnapshot> OnPushSuccess;
+        public Action<SimpleFirebase, SimpleFirebaseError> OnPushFailed;
 
-        public Action<Firebase, DataSnapshot> OnDeleteSuccess;
-        public Action<Firebase, FirebaseError> OnDeleteFailed;
+        public Action<SimpleFirebase, SimpleDataSnapshot> OnDeleteSuccess;
+        public Action<SimpleFirebase, SimpleFirebaseError> OnDeleteFailed;
 
-        protected Firebase parent;
-        internal FirebaseRoot root;
+        protected SimpleFirebase parent;
+        internal SimpleFirebaseRoot root;
         protected string key;
         protected string fullKey;
 
@@ -70,7 +70,7 @@ namespace SimpleFirebaseUnity
         /// <summary>
         /// Parent of current firebase pointer
         /// </summary>                 
-        public Firebase Parent
+        public SimpleFirebase Parent
         {
             get
             {
@@ -81,7 +81,7 @@ namespace SimpleFirebaseUnity
         /// <summary>
         /// Root firebase pointer of the endpoint
         /// </summary>
-        public Firebase Root
+        public SimpleFirebase Root
         {
             get
             {
@@ -171,7 +171,7 @@ namespace SimpleFirebaseUnity
         /// <param name="_key">Key under parent Firebase</param>
         /// <param name="_root">Root Firebase pointer</param>
         /// <param name="inheritCallback">If set to <c>true</c> inherit callback.</param>
-        internal Firebase(Firebase _parent, string _key, FirebaseRoot _root, bool inheritCallback = false)
+        internal SimpleFirebase(SimpleFirebase _parent, string _key, SimpleFirebaseRoot _root, bool inheritCallback = false)
         {
             parent = _parent;
             key = _key;
@@ -198,7 +198,7 @@ namespace SimpleFirebaseUnity
             }
         }
 
-        internal Firebase()
+        internal SimpleFirebase()
         {
             parent = null;
             key = string.Empty;
@@ -214,18 +214,18 @@ namespace SimpleFirebaseUnity
         /// </summary>
         /// <param name="_key">A string</param>
         /// <param name="inheritCallback">If set to <c>true</c> inherit callback.</param>
-        public Firebase Child(string _key, bool inheritCallback = false)
+        public SimpleFirebase Child(string _key, bool inheritCallback = false)
         {
-            return new Firebase(this, _key, root, inheritCallback);
+            return new SimpleFirebase(this, _key, root, inheritCallback);
         }
 
         /// <summary>
         /// Get Firebase childs from given keys
         /// </summary>
         /// <param name="_keys">List of string</param>
-        public List<Firebase> Childs(List<string> _keys)
+        public List<SimpleFirebase> Childs(List<string> _keys)
         {
-            List<Firebase> childs = new List<Firebase>();
+            List<SimpleFirebase> childs = new List<SimpleFirebase>();
             foreach (string k in _keys)
                 childs.Add(Child(k));
             return childs;
@@ -235,9 +235,9 @@ namespace SimpleFirebaseUnity
         /// Get Firebase childs from given keys
         /// </summary>
         /// <param name="_keys">Array of string</param>
-        public List<Firebase> Childs(string[] _keys)
+        public List<SimpleFirebase> Childs(string[] _keys)
         {
-            List<Firebase> childs = new List<Firebase>();
+            List<SimpleFirebase> childs = new List<SimpleFirebase>();
             foreach (string k in _keys)
                 childs.Add(Child(k));
 
@@ -248,13 +248,13 @@ namespace SimpleFirebaseUnity
         /// Get a fresh copy of this Firebase object
         /// </summary>
         /// <param name="inheritCallback">If set to <c>true</c> inherit callback.</param>
-        public Firebase Copy(bool inheritCallback = false)
+        public SimpleFirebase Copy(bool inheritCallback = false)
         {
-            Firebase temp;
+            SimpleFirebase temp;
             if (parent == null)
                 temp = root.Copy();
             else
-                temp = new Firebase(parent, key, root);
+                temp = new SimpleFirebase(parent, key, root);
 
             if (inheritCallback)
             {
@@ -288,7 +288,7 @@ namespace SimpleFirebaseUnity
         /// </summary>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void GetValue(FirebaseParam query)
+        public void GetValue(SimpleFirebaseParam query)
         {
             GetValue(query.Parameter);
         }
@@ -306,7 +306,7 @@ namespace SimpleFirebaseUnity
             {
                 if (Credential != "")
                 {
-                    param = (new FirebaseParam(param).Auth(Credential)).Parameter;
+                    param = (new SimpleFirebaseParam(param).Auth(Credential)).Parameter;
                 }
 
                 string url = Endpoint;
@@ -320,11 +320,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnGetFailed != null) OnGetFailed(this, FirebaseError.Create(webEx));
+                if (OnGetFailed != null) OnGetFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnGetFailed != null) OnGetFailed(this, new FirebaseError(ex.Message));
+                if (OnGetFailed != null) OnGetFailed(this, new SimpleFirebaseError(ex.Message));
             }
 
         }
@@ -360,7 +360,7 @@ namespace SimpleFirebaseUnity
             {
                 if (Credential != "")
                 {
-                    param = (new FirebaseParam(param).Auth(Credential)).Parameter;
+                    param = (new SimpleFirebaseParam(param).Auth(Credential)).Parameter;
                 }
 
                 string url = Endpoint;
@@ -381,11 +381,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnSetFailed != null) OnSetFailed(this, FirebaseError.Create(webEx));
+                if (OnSetFailed != null) OnSetFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnSetFailed != null) OnSetFailed(this, new FirebaseError(ex.Message));
+                if (OnSetFailed != null) OnSetFailed(this, new SimpleFirebaseError(ex.Message));
             }
 
         }
@@ -399,7 +399,7 @@ namespace SimpleFirebaseUnity
         /// <param name="isJson">True if string is json (necessary to differentiate the other overloading)</param>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void SetValue(string json, bool isJson, FirebaseParam query)
+        public void SetValue(string json, bool isJson, SimpleFirebaseParam query)
         {
             if (!isJson)
                 SetValue(json, query.Parameter);
@@ -415,7 +415,7 @@ namespace SimpleFirebaseUnity
         /// <param name="_val">Update value</param>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void SetValue(object _val, FirebaseParam query)
+        public void SetValue(object _val, SimpleFirebaseParam query)
         {
             SetValue(_val, query.Parameter);
         }
@@ -437,14 +437,14 @@ namespace SimpleFirebaseUnity
                 if (!(_val is Dictionary<string, object>))
                 {
                     if (OnUpdateFailed != null)
-                        OnUpdateFailed(this, new FirebaseError((HttpStatusCode)400, "Invalid data; couldn't parse JSON object. Are you sending a JSON object with valid key names?"));
+                        OnUpdateFailed(this, new SimpleFirebaseError((HttpStatusCode)400, "Invalid data; couldn't parse JSON object. Are you sending a JSON object with valid key names?"));
 
                     return;
                 }
 
                 if (Credential != "")
                 {
-                    param = (new FirebaseParam(param).Auth(Credential)).Parameter;
+                    param = (new SimpleFirebaseParam(param).Auth(Credential)).Parameter;
                 }
 
                 string url = Endpoint;
@@ -465,11 +465,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnUpdateFailed != null) OnUpdateFailed(this, FirebaseError.Create(webEx));
+                if (OnUpdateFailed != null) OnUpdateFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnUpdateFailed != null) OnUpdateFailed(this, new FirebaseError(ex.Message));
+                if (OnUpdateFailed != null) OnUpdateFailed(this, new SimpleFirebaseError(ex.Message));
             }
 
         }
@@ -483,7 +483,7 @@ namespace SimpleFirebaseUnity
         /// <param name="isJson">True if string is json (necessary to differentiate the other overloading)</param>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void UpdateValue(string json, bool isJson, FirebaseParam query)
+        public void UpdateValue(string json, bool isJson, SimpleFirebaseParam query)
         {
             if (!isJson)
                 UpdateValue(json, query.Parameter);
@@ -499,7 +499,7 @@ namespace SimpleFirebaseUnity
         /// <param name="_val">Update value</param>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void UpdateValue(object _val, FirebaseParam query)
+        public void UpdateValue(object _val, SimpleFirebaseParam query)
         {
             UpdateValue(_val, query.Parameter);
         }
@@ -535,7 +535,7 @@ namespace SimpleFirebaseUnity
             {
                 if (Credential != "")
                 {
-                    param = (new FirebaseParam(param).Auth(Credential)).Parameter;
+                    param = (new SimpleFirebaseParam(param).Auth(Credential)).Parameter;
                 }
 
                 string url = Endpoint;
@@ -553,11 +553,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnPushFailed != null) OnPushFailed(this, FirebaseError.Create(webEx));
+                if (OnPushFailed != null) OnPushFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnPushFailed != null) OnPushFailed(this, new FirebaseError(ex.Message));
+                if (OnPushFailed != null) OnPushFailed(this, new SimpleFirebaseError(ex.Message));
             }
         }
 
@@ -570,7 +570,7 @@ namespace SimpleFirebaseUnity
         /// <param name="isJson">True if string is json (necessary to differentiate with the other overloading)</param>
         /// <param name="param">REST call parameters on a string. Example: "auth=ASDF123"</param>
         /// <returns></returns>
-        public void Push(string json, bool isJson, FirebaseParam query)
+        public void Push(string json, bool isJson, SimpleFirebaseParam query)
         {
             if (!isJson)
                 Push(json, query.Parameter);
@@ -586,7 +586,7 @@ namespace SimpleFirebaseUnity
         /// <param name="_val">New value</param>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void Push(object _val, FirebaseParam query)
+        public void Push(object _val, SimpleFirebaseParam query)
         {
             Push(_val, query.Parameter);
         }
@@ -604,7 +604,7 @@ namespace SimpleFirebaseUnity
             {
                 if (Credential != "")
                 {
-                    param = (new FirebaseParam(param).Auth(Credential)).Parameter;
+                    param = (new SimpleFirebaseParam(param).Auth(Credential)).Parameter;
                 }
 
                 string url = Endpoint;
@@ -626,11 +626,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnDeleteFailed != null) OnDeleteFailed(this, FirebaseError.Create(webEx));
+                if (OnDeleteFailed != null) OnDeleteFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnDeleteFailed != null) OnDeleteFailed(this, new FirebaseError(ex.Message));
+                if (OnDeleteFailed != null) OnDeleteFailed(this, new SimpleFirebaseError(ex.Message));
             }
         }
 
@@ -641,7 +641,7 @@ namespace SimpleFirebaseUnity
         /// </summary>
         /// <param name="query">REST call parameters wrapped in FirebaseQuery class</param>
         /// <returns></returns>
-        public void Delete(FirebaseParam query)
+        public void Delete(SimpleFirebaseParam query)
         {
             Delete(query.Parameter);
         }
@@ -662,9 +662,9 @@ namespace SimpleFirebaseUnity
         /// <param name="keyName">Key name.</param>
         /// <param name="OnSuccess">On success callback.</param>
         /// <param name="OnFailed">On fail callback.</param>
-        public void SetTimeStamp(string keyName, Action<Firebase, DataSnapshot> OnSuccess, Action<Firebase, FirebaseError> OnFailed)
+        public void SetTimeStamp(string keyName, Action<SimpleFirebase, SimpleDataSnapshot> OnSuccess, Action<SimpleFirebase, SimpleFirebaseError> OnFailed)
         {
-            Firebase temp = Child(keyName);
+            SimpleFirebase temp = Child(keyName);
             temp.OnSetSuccess += OnSuccess;
             temp.OnSetFailed += OnFailed;
 
@@ -678,7 +678,7 @@ namespace SimpleFirebaseUnity
         /// <param name="OnSuccess">On success callback.</param>
         /// <param name="OnFailed">On failed callback.</param>
         /// <param name="secret">Firebase Secret.</param>
-        public void GetRules(Action<Firebase, DataSnapshot> OnSuccess, Action<Firebase, FirebaseError> OnFailed, string secret = "")
+        public void GetRules(Action<SimpleFirebase, SimpleDataSnapshot> OnSuccess, Action<SimpleFirebase, SimpleFirebaseError> OnFailed, string secret = "")
         {
             try
             {
@@ -696,11 +696,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnFailed != null) OnFailed(this, FirebaseError.Create(webEx));
+                if (OnFailed != null) OnFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnFailed != null) OnFailed(this, new FirebaseError(ex.Message));
+                if (OnFailed != null) OnFailed(this, new SimpleFirebaseError(ex.Message));
             }
         }
 
@@ -711,7 +711,7 @@ namespace SimpleFirebaseUnity
         /// <param name="OnSuccess">On success callback.</param>
         /// <param name="OnFailed">On failed callback.</param>
         /// <param name="secret">Firebase Secret.</param>
-        public void SetRules(string json, Action<Firebase, DataSnapshot> OnSuccess, Action<Firebase, FirebaseError> OnFailed, string secret = "")
+        public void SetRules(string json, Action<SimpleFirebase, SimpleDataSnapshot> OnSuccess, Action<SimpleFirebase, SimpleFirebaseError> OnFailed, string secret = "")
         {
             try
             {
@@ -736,11 +736,11 @@ namespace SimpleFirebaseUnity
             }
             catch (WebException webEx)
             {
-                if (OnFailed != null) OnFailed(this, FirebaseError.Create(webEx));
+                if (OnFailed != null) OnFailed(this, SimpleFirebaseError.Create(webEx));
             }
             catch (Exception ex)
             {
-                if (OnFailed != null) OnFailed(this, new FirebaseError(ex.Message));
+                if (OnFailed != null) OnFailed(this, new SimpleFirebaseError(ex.Message));
             }
         }
 
@@ -761,7 +761,7 @@ namespace SimpleFirebaseUnity
         /// <param name="OnSuccess">On success.</param>
         /// <param name="OnFailed">On failed.</param>
         /// <param name="secret">Firebase Secret.</param>
-        public void SetRules(Dictionary<string, object> rules, Action<Firebase, DataSnapshot> OnSuccess, Action<Firebase, FirebaseError> OnFailed, string secret = "")
+        public void SetRules(Dictionary<string, object> rules, Action<SimpleFirebase, SimpleDataSnapshot> OnSuccess, Action<SimpleFirebase, SimpleFirebaseError> OnFailed, string secret = "")
         {
             SetRules(Json.Serialize(rules), OnSuccess, OnFailed, secret);
         }
@@ -780,7 +780,7 @@ namespace SimpleFirebaseUnity
 
         #region REQUEST COROUTINE
 
-        protected IEnumerator RequestCoroutine(string url, byte[] postData, Dictionary<string, string> headers, Action<Firebase, DataSnapshot> OnSuccess, Action<Firebase, FirebaseError> OnFailed)
+        protected IEnumerator RequestCoroutine(string url, byte[] postData, Dictionary<string, string> headers, Action<SimpleFirebase, SimpleDataSnapshot> OnSuccess, Action<SimpleFirebase, SimpleFirebaseError> OnFailed)
         {
             using (WWW www = (headers != null) ? new WWW(url, postData, headers) : (postData != null) ? new WWW(url, postData) : new WWW(url))
             {
@@ -838,7 +838,7 @@ namespace SimpleFirebaseUnity
                             errMessage = "Request failed with no info of error.";
                         }
 
-                        OnFailed(this, new FirebaseError(status, errMessage));
+                        OnFailed(this, new SimpleFirebaseError(status, errMessage));
                     }
 
 #if UNITY_EDITOR
@@ -847,7 +847,7 @@ namespace SimpleFirebaseUnity
                 }
                 else
                 {
-                    DataSnapshot snapshot = new DataSnapshot(www.text);
+                    SimpleDataSnapshot snapshot = new SimpleDataSnapshot(www.text);
                     if (OnSuccess != null) OnSuccess(this, snapshot);
                 }
             }
@@ -863,9 +863,9 @@ namespace SimpleFirebaseUnity
         /// <param name="host">Example: "hostname.firebaseio.com" (with no https://)</param>
         /// <param name="credential">Credential value for auth parameter</param>
         /// <returns></returns>
-        public static Firebase CreateNew(string host, string credential = "")
+        public static SimpleFirebase CreateNew(string host, string credential = "")
         {
-            return new FirebaseRoot(host, credential);
+            return new SimpleFirebaseRoot(host, credential);
         }
 
         /// <summary>

--- a/SimpleFirebaseUnity/SimpleFirebaseError.cs
+++ b/SimpleFirebaseUnity/SimpleFirebaseError.cs
@@ -35,7 +35,7 @@ using System.Net;
 
 namespace SimpleFirebaseUnity
 {
-    public class FirebaseError : Exception
+    public class SimpleFirebaseError : Exception
     {
 		const string MESSAGE_ERROR_400 = "Firebase request has invalid child names or invalid/missing/too large data";
 		const string MESSAGE_ERROR_401 = "Firebase request's authorization has failed";
@@ -47,21 +47,21 @@ namespace SimpleFirebaseUnity
 		protected HttpStatusCode m_Status;
 
 
-		public FirebaseError(HttpStatusCode status, string message) : base(message)
+		public SimpleFirebaseError(HttpStatusCode status, string message) : base(message)
 		{
 			m_Status = status;
 		}
 
-		public FirebaseError(HttpStatusCode status, string message, Exception inner) : base(message, inner)
+		public SimpleFirebaseError(HttpStatusCode status, string message, Exception inner) : base(message, inner)
 		{
 			m_Status = status;
 		}
 
-		public FirebaseError(string message) : base(message)
+		public SimpleFirebaseError(string message) : base(message)
 		{
 		}
 
-		public FirebaseError(string message, Exception inner) : base(message, inner)
+		public SimpleFirebaseError(string message, Exception inner) : base(message, inner)
 		{
 		}
 
@@ -70,7 +70,7 @@ namespace SimpleFirebaseUnity
 		/// Create the FirebaseError initialized based on the given WebException.
 		/// </summary>
 		/// <param name="webEx">Web exception.</param>
-		public static FirebaseError Create(WebException webEx)
+		public static SimpleFirebaseError Create(WebException webEx)
 		{
 			string message;
 			HttpStatusCode status = 0;
@@ -87,7 +87,7 @@ namespace SimpleFirebaseUnity
 			}
 
 			if (!isStatusAvailable)
-				return new FirebaseError(webEx.Message, webEx);
+				return new SimpleFirebaseError(webEx.Message, webEx);
 
 			switch (status) 
 			{
@@ -111,14 +111,14 @@ namespace SimpleFirebaseUnity
 					break;
 			}
 
-			return new FirebaseError(status, message, webEx);
+			return new SimpleFirebaseError(status, message, webEx);
 		}
 			
 		/// <summary>
 		/// Create the FirebaseError initialized based on the given http status code.
 		/// </summary>
 		/// <param name="status">Http status code.</param>
-		public static FirebaseError Create(HttpStatusCode status)
+		public static SimpleFirebaseError Create(HttpStatusCode status)
 		{
 			string message;
 
@@ -144,7 +144,7 @@ namespace SimpleFirebaseUnity
 					break;
 			}
 
-			return  new FirebaseError (status, message);
+			return  new SimpleFirebaseError (status, message);
 		}
 
 		/// <summary>

--- a/SimpleFirebaseUnity/SimpleFirebaseManager.cs
+++ b/SimpleFirebaseUnity/SimpleFirebaseManager.cs
@@ -35,15 +35,15 @@ using UnityEngine;
 namespace SimpleFirebaseUnity
 {
     [ExecuteInEditMode]
-    public class FirebaseManager : MonoBehaviour
+    public class SimpleFirebaseManager : MonoBehaviour
     {
 
-        private static FirebaseManager _instance;
+        private static SimpleFirebaseManager _instance;
         private static object _lock = new object();
 
-        protected FirebaseManager() { }
+        protected SimpleFirebaseManager() { }
 
-        public static FirebaseManager Instance
+        public static SimpleFirebaseManager Instance
         {
             get
             {
@@ -58,7 +58,7 @@ namespace SimpleFirebaseUnity
                 {
                     if (_instance == null)
                     {
-                        FirebaseManager[] managers = FindObjectsOfType<FirebaseManager>();
+                        SimpleFirebaseManager[] managers = FindObjectsOfType<SimpleFirebaseManager>();
 
                         _instance = (managers.Length > 0) ? managers[0] : null;
 
@@ -74,7 +74,7 @@ namespace SimpleFirebaseUnity
                         if (_instance == null)
                         {
                             GameObject singleton = new GameObject();
-                            _instance = singleton.AddComponent<FirebaseManager>();
+                            _instance = singleton.AddComponent<SimpleFirebaseManager>();
                             singleton.name = "Firebase Manager [Singleton]";
 
                             DontDestroyOnLoad(singleton);

--- a/SimpleFirebaseUnity/SimpleFirebaseObserver.cs
+++ b/SimpleFirebaseUnity/SimpleFirebaseObserver.cs
@@ -36,18 +36,18 @@ using System;
 
 namespace SimpleFirebaseUnity
 {
-	public class FirebaseObserver  {
+	public class SimpleFirebaseObserver  {
 
-		public Action<Firebase, DataSnapshot> OnChange; 
+		public Action<SimpleFirebase, SimpleDataSnapshot> OnChange; 
 
-		protected Firebase firebase;
-		protected Firebase target;
+		protected SimpleFirebase firebase;
+		protected SimpleFirebase target;
 		protected float refreshRate;
 		protected string getParam;
 		protected bool active;
 
 		protected bool firstTime;
-		protected DataSnapshot lastSnapshot;
+		protected SimpleDataSnapshot lastSnapshot;
 
 		protected IEnumerator routine;
 
@@ -60,7 +60,7 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="refreshRate">Refresh rate (in seconds).</param>
 		/// <param name="getParam">Parameter value for the Get request that will be called periodically.</param>
-		public FirebaseObserver(Firebase _firebase, float _refreshRate, string _getParam = "")
+		public SimpleFirebaseObserver(SimpleFirebase _firebase, float _refreshRate, string _getParam = "")
 		{
 			active = false;
 			lastSnapshot = null;
@@ -77,7 +77,7 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="refreshRate">Refresh rate (in seconds).</param>
 		/// <param name="getParam">Parameter value for the Get request that will be called periodically.</param>
-		public FirebaseObserver(Firebase _firebase, float _refreshRate, FirebaseParam _getParam)
+		public SimpleFirebaseObserver(SimpleFirebase _firebase, float _refreshRate, SimpleFirebaseParam _getParam)
 		{
 			active = false;
 			lastSnapshot = null;
@@ -134,7 +134,7 @@ namespace SimpleFirebaseUnity
 			}
 		}
 
-		void CompareSnapshot(Firebase target, DataSnapshot snapshot)
+		void CompareSnapshot(SimpleFirebase target, SimpleDataSnapshot snapshot)
 		{
 			if (firstTime) {
 				firstTime = false;

--- a/SimpleFirebaseUnity/SimpleFirebaseParam.cs
+++ b/SimpleFirebaseUnity/SimpleFirebaseParam.cs
@@ -34,7 +34,7 @@ using UnityEngine;
 
 namespace SimpleFirebaseUnity
 {
-	public struct FirebaseParam
+	public struct SimpleFirebaseParam
 	{
 		string param;
 
@@ -64,7 +64,7 @@ namespace SimpleFirebaseUnity
 		/// Create new FirebaseQuery
 		/// </summary>
 		/// <param name="param">REST call parameters on a string. Example: &quot;orderBy=&#92;"$key&#92;"&quot;print=pretty&quot;auth=secret123"></param>
-		public FirebaseParam(string _param = "")
+		public SimpleFirebaseParam(string _param = "")
 		{
 			param = _param;
 		}
@@ -72,7 +72,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam Add(string parameter)
+		public SimpleFirebaseParam Add(string parameter)
 		{
 			if (param != null && param.Length > 0)
 				param += "&";
@@ -84,7 +84,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data . Set quoted parameter if necessary
 		/// </summary>
-		public FirebaseParam Add(string header, string value, bool quoted = true)
+		public SimpleFirebaseParam Add(string header, string value, bool quoted = true)
 		{
 			return (quoted) ? Add(header + "=\"" + value + "\"") : Add(header + "=" + value);
 		}
@@ -92,7 +92,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam Add(string header, int value)
+		public SimpleFirebaseParam Add(string header, int value)
 		{
 			return Add(header + "=" + value);
 		}
@@ -100,7 +100,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam Add(string header, float value)
+		public SimpleFirebaseParam Add(string header, float value)
 		{
 			return Add(header + "=" + value);
 		}
@@ -108,7 +108,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam Add(string header, bool value)
+		public SimpleFirebaseParam Add(string header, bool value)
 		{
 			return Add(header + "=" + value);
 		}
@@ -116,7 +116,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam OrderByChild(string key)
+		public SimpleFirebaseParam OrderByChild(string key)
 		{
 			return Add("orderBy", key);
 		}
@@ -124,7 +124,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam OrderByKey()
+		public SimpleFirebaseParam OrderByKey()
 		{
 			return Add("orderBy", "$key");
 		}
@@ -132,7 +132,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam OrderByValue()
+		public SimpleFirebaseParam OrderByValue()
 		{
 			return Add("orderBy", "$value");
 		}
@@ -140,7 +140,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam OrderByPriority()
+		public SimpleFirebaseParam OrderByPriority()
 		{
 			return Add("orderBy", "$priority");
 		}
@@ -148,7 +148,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam LimitToFirst(int lim)
+		public SimpleFirebaseParam LimitToFirst(int lim)
 		{
 			return Add("limitToFirst", lim);
 		}
@@ -156,7 +156,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam LimitToLast(int lim)
+		public SimpleFirebaseParam LimitToLast(int lim)
 		{
 			return Add("limitToLast", lim);
 		}
@@ -164,7 +164,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam StartAt(string start)
+		public SimpleFirebaseParam StartAt(string start)
 		{
 			return Add("startAt", start);
 		}
@@ -172,7 +172,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam StartAt(int start)
+		public SimpleFirebaseParam StartAt(int start)
 		{
 			return Add("startAt", start);
 		}
@@ -180,7 +180,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam StartAt(bool start)
+		public SimpleFirebaseParam StartAt(bool start)
 		{
 			return Add("startAt", start);
 		}
@@ -188,7 +188,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam StartAt(float start)
+		public SimpleFirebaseParam StartAt(float start)
 		{
 			return Add("startAt", start);
 		}
@@ -196,7 +196,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EndAt(string end)
+		public SimpleFirebaseParam EndAt(string end)
 		{
 			return Add("endAt", end);
 		}
@@ -204,7 +204,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EndAt(int end)
+		public SimpleFirebaseParam EndAt(int end)
 		{
 			return Add("endAt", end);
 		}
@@ -212,7 +212,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EndAt(bool end)
+		public SimpleFirebaseParam EndAt(bool end)
 		{
 			return Add("endAt", end);
 		}
@@ -220,7 +220,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EndAt(float end)
+		public SimpleFirebaseParam EndAt(float end)
 		{
 			return Add("endAt", end);
 		}
@@ -228,7 +228,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EqualTo(string at)
+		public SimpleFirebaseParam EqualTo(string at)
 		{
 			return Add("equalTo", at);
 		}
@@ -236,7 +236,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EqualTo(int at)
+		public SimpleFirebaseParam EqualTo(int at)
 		{
 			return Add("equalTo", at);
 		}
@@ -244,7 +244,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EqualTo(bool at)
+		public SimpleFirebaseParam EqualTo(bool at)
 		{
 			return Add("equalTo", at);
 		}
@@ -252,7 +252,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam EqualTo(float at)
+		public SimpleFirebaseParam EqualTo(float at)
 		{
 			return Add("equalTo", at);
 		}
@@ -260,7 +260,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam PrintPretty()
+		public SimpleFirebaseParam PrintPretty()
 		{
 			return Add("print=pretty");
 		}
@@ -268,7 +268,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam PrintSilent()
+		public SimpleFirebaseParam PrintSilent()
 		{
 			return Add("print=silent");
 		}
@@ -276,7 +276,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam Shallow()
+		public SimpleFirebaseParam Shallow()
 		{
 			return Add("shallow=true");
 		}
@@ -284,7 +284,7 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// For details see https://firebase.google.com/docs/database/rest/retrieve-data
 		/// </summary>
-		public FirebaseParam Auth(string cred)
+		public SimpleFirebaseParam Auth(string cred)
 		{
 			return Add("auth=" + cred);
 		}
@@ -297,11 +297,11 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// Empty paramete or \"\"
 		/// </summary>
-		public static FirebaseParam Empty
+		public static SimpleFirebaseParam Empty
 		{
 			get
 			{
-				return new FirebaseParam();
+				return new SimpleFirebaseParam();
 			}
 		}
 	}

--- a/SimpleFirebaseUnity/SimpleFirebaseQueue.cs
+++ b/SimpleFirebaseUnity/SimpleFirebaseQueue.cs
@@ -36,7 +36,7 @@ namespace SimpleFirebaseUnity
 {
 	using MiniJSON;
 
-	public class FirebaseQueue {
+	public class SimpleFirebaseQueue {
 
 		#region FIREBASE COMMAND QUEUE
 
@@ -52,13 +52,13 @@ namespace SimpleFirebaseUnity
 		}
 
 		protected class CommandLinkedList {
-			public Firebase firebase;
+			public SimpleFirebase firebase;
 			FirebaseCommand command;
 			string param;
 			object obj;
 			public CommandLinkedList next;
 
-			public CommandLinkedList(Firebase _firebase, FirebaseCommand _command, string _param, object _obj = null){
+			public CommandLinkedList(SimpleFirebase _firebase, FirebaseCommand _command, string _param, object _obj = null){
 				firebase = _firebase;
 				command = _command;
 				param = _param;
@@ -66,7 +66,7 @@ namespace SimpleFirebaseUnity
 				next = null;
 			}
 
-			public CommandLinkedList(Firebase _firebase, FirebaseCommand _command, FirebaseParam firebaseParam, object _obj = null){
+			public CommandLinkedList(SimpleFirebase _firebase, FirebaseCommand _command, SimpleFirebaseParam firebaseParam, object _obj = null){
 				firebase = _firebase;
 				command = _command;
 				param = firebaseParam.Parameter;
@@ -107,7 +107,7 @@ namespace SimpleFirebaseUnity
 		protected bool autoStart;
 		protected int count;
 
-		protected void AddQueue(Firebase firebase, FirebaseCommand command, string param, object obj = null)
+		protected void AddQueue(SimpleFirebase firebase, FirebaseCommand command, string param, object obj = null)
 		{
 			CommandLinkedList commandNode =  new CommandLinkedList (firebase, command, param, obj);
 
@@ -144,21 +144,21 @@ namespace SimpleFirebaseUnity
 			}
 		}
 
-		protected void OnSuccess(Firebase sender, DataSnapshot snapshot)
+		protected void OnSuccess(SimpleFirebase sender, SimpleDataSnapshot snapshot)
 		{
 			--count;
 			StartNextCommand ();
 			ClearCallbacks (sender);
 		}
 
-		protected void OnFailed(Firebase sender, FirebaseError err)
+		protected void OnFailed(SimpleFirebase sender, SimpleFirebaseError err)
 		{
 			--count;
 			StartNextCommand ();
 			ClearCallbacks (sender);
 		}
 
-		protected void ClearCallbacks(Firebase sender)
+		protected void ClearCallbacks(SimpleFirebase sender)
 		{
 			sender.OnGetSuccess -= OnSuccess;
 			sender.OnGetFailed -= OnFailed;
@@ -178,7 +178,7 @@ namespace SimpleFirebaseUnity
 		/// Initializes a new instance of the <see cref="SimpleFirebaseUnity.FirebaseQueueManager"/> class.
 		/// </summary>
 		/// <param name="_autoStart">If set to <c>true</c> auto start when a queue added.</param>
-		public FirebaseQueue(bool _autoStart = true)
+		public SimpleFirebaseQueue(bool _autoStart = true)
 		{
 			autoStart = _autoStart;
 			count = 0;
@@ -209,9 +209,9 @@ namespace SimpleFirebaseUnity
 		/// </summary>
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueGet(Firebase firebase, string param = "")
+		public void AddQueueGet(SimpleFirebase firebase, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnGetSuccess += OnSuccess;
 			temp.OnGetFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Get, param);
@@ -222,9 +222,9 @@ namespace SimpleFirebaseUnity
 		/// </summary>
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueGet(Firebase firebase, FirebaseParam param)
+		public void AddQueueGet(SimpleFirebase firebase, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnGetSuccess += OnSuccess;
 			temp.OnGetFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Get, param.Parameter);
@@ -237,9 +237,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="val">Value.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueSet(Firebase firebase, object val, string param = "")
+		public void AddQueueSet(SimpleFirebase firebase, object val, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnSetSuccess += OnSuccess;
 			temp.OnSetFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Set, param, val);
@@ -251,9 +251,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="val">Value.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueSet(Firebase firebase, object val, FirebaseParam param)
+		public void AddQueueSet(SimpleFirebase firebase, object val, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnSetSuccess += OnSuccess;
 			temp.OnSetFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Set, param.Parameter, val);
@@ -266,9 +266,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="json">Json.</param>
 		/// <param name="isJson">If set to <c>true</c> is json.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueSet(Firebase firebase, string json, bool isJson, string param = "")
+		public void AddQueueSet(SimpleFirebase firebase, string json, bool isJson, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnSetSuccess += OnSuccess;
 			temp.OnSetFailed += OnFailed;
 			if (!isJson)
@@ -284,9 +284,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="json">Json.</param>
 		/// <param name="isJson">If set to <c>true</c> is json.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueSet(Firebase firebase, string json, bool isJson, FirebaseParam param)
+		public void AddQueueSet(SimpleFirebase firebase, string json, bool isJson, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnSetSuccess += OnSuccess;
 			temp.OnSetFailed += OnFailed;
 			if (!isJson)
@@ -301,7 +301,7 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="val">Value.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueUpdate(Firebase firebase, object val, string param = "")
+		public void AddQueueUpdate(SimpleFirebase firebase, object val, string param = "")
 		{
 			firebase.OnUpdateSuccess += OnSuccess;
 			firebase.OnUpdateFailed += OnFailed;
@@ -314,9 +314,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="val">Value.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueUpdate(Firebase firebase, object val, FirebaseParam param)
+		public void AddQueueUpdate(SimpleFirebase firebase, object val, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnUpdateSuccess += OnSuccess;
 			temp.OnUpdateFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Update, param.Parameter, val);
@@ -329,9 +329,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="json">Json.</param>
 		/// <param name="isJson">If set to <c>true</c> is json.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueUpdate(Firebase firebase, string json, bool isJson, string param = "")
+		public void AddQueueUpdate(SimpleFirebase firebase, string json, bool isJson, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnUpdateSuccess += OnSuccess;
 			temp.OnUpdateFailed += OnFailed;
 			if (!isJson)
@@ -347,9 +347,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="json">Json.</param>
 		/// <param name="isJson">If set to <c>true</c> is json.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueUpdate(Firebase firebase, string json, bool isJson, FirebaseParam param)
+		public void AddQueueUpdate(SimpleFirebase firebase, string json, bool isJson, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnUpdateSuccess += OnSuccess;
 			temp.OnUpdateFailed += OnFailed;
 			if (!isJson)
@@ -364,9 +364,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="val">Value.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueuePush(Firebase firebase, object val, string param = "")
+		public void AddQueuePush(SimpleFirebase firebase, object val, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnPushSuccess += OnSuccess;
 			temp.OnPushFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Push, param, val);
@@ -378,9 +378,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="val">Value.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueuePush(Firebase firebase, object val, FirebaseParam param)
+		public void AddQueuePush(SimpleFirebase firebase, object val, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnPushSuccess += OnSuccess;
 			temp.OnPushFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Push, param.Parameter, val);
@@ -393,9 +393,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="json">Json.</param>
 		/// <param name="isJson">If set to <c>true</c> is json.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueuePush(Firebase firebase, string json, bool isJson, string param = "")
+		public void AddQueuePush(SimpleFirebase firebase, string json, bool isJson, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnPushSuccess += OnSuccess;
 			temp.OnPushFailed += OnFailed;
 			if (!isJson)
@@ -411,9 +411,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="json">Json.</param>
 		/// <param name="isJson">If set to <c>true</c> is json.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueuePush(Firebase firebase, string json, bool isJson, FirebaseParam param)
+		public void AddQueuePush(SimpleFirebase firebase, string json, bool isJson, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnPushSuccess += OnSuccess;
 			temp.OnPushFailed += OnFailed;
 			if (!isJson)
@@ -427,9 +427,9 @@ namespace SimpleFirebaseUnity
 		/// </summary>
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueDelete(Firebase firebase, string param = "")
+		public void AddQueueDelete(SimpleFirebase firebase, string param = "")
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnDeleteSuccess += OnSuccess;
 			temp.OnDeleteFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Delete, param);
@@ -440,9 +440,9 @@ namespace SimpleFirebaseUnity
 		/// </summary>
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="param">Parameter.</param>
-		public void AddQueueDelete(Firebase firebase, FirebaseParam param)
+		public void AddQueueDelete(SimpleFirebase firebase, SimpleFirebaseParam param)
 		{
-			Firebase temp = firebase.Copy (true);
+			SimpleFirebase temp = firebase.Copy (true);
 			temp.OnDeleteSuccess += OnSuccess;
 			temp.OnDeleteFailed += OnFailed;
 			AddQueue (temp, FirebaseCommand.Delete, param.Parameter);
@@ -453,9 +453,9 @@ namespace SimpleFirebaseUnity
 		/// </summary>
 		/// <param name="firebase">Firebase.</param>
 		/// <param name="keyName">Time stamp key name.</param>
-		public void AddQueueSetTimeStamp(Firebase firebase, string keyName)
+		public void AddQueueSetTimeStamp(SimpleFirebase firebase, string keyName)
 		{
-			Firebase temp = firebase.Child (keyName, false);
+			SimpleFirebase temp = firebase.Child (keyName, false);
 			AddQueueSet (temp, SERVER_VALUE_TIMESTAMP, true, "print=silent");
 		}
 
@@ -466,9 +466,9 @@ namespace SimpleFirebaseUnity
 		/// <param name="keyName">Key name.</param>
 		/// <param name="_OnSuccess">On success callback.</param>
 		/// <param name="_OnFailed">On fail callback.</param>
-		public void AddQueueSetTimeStamp(Firebase firebase, string keyName, Action<Firebase, DataSnapshot> _OnSuccess, Action<Firebase, FirebaseError> _OnFailed)
+		public void AddQueueSetTimeStamp(SimpleFirebase firebase, string keyName, Action<SimpleFirebase, SimpleDataSnapshot> _OnSuccess, Action<SimpleFirebase, SimpleFirebaseError> _OnFailed)
 		{
-			Firebase temp = firebase.Child (keyName);
+			SimpleFirebase temp = firebase.Child (keyName);
 			temp.OnSetSuccess += _OnSuccess;
 			temp.OnSetFailed += _OnFailed;
 

--- a/SimpleFirebaseUnity/SimpleFirebaseRoot.cs
+++ b/SimpleFirebaseUnity/SimpleFirebaseRoot.cs
@@ -37,7 +37,7 @@ using System.Collections;
 
 namespace SimpleFirebaseUnity
 {
-    internal class FirebaseRoot : Firebase
+    internal class SimpleFirebaseRoot : SimpleFirebase
     {
 		protected static bool firstTimeInitiated = true;
 		protected string host;
@@ -84,17 +84,17 @@ namespace SimpleFirebaseUnity
 		/// <summary>
 		/// Copy this instance.
 		/// </summary>
-		public FirebaseRoot Copy()
+		public SimpleFirebaseRoot Copy()
 		{
-			return new FirebaseRoot (host, cred);
+			return new SimpleFirebaseRoot (host, cred);
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="SimpleFirebaseUnity.FirebaseRoot"/> class.
+		/// Initializes a new instance of the <see cref="SimpleFirebaseUnity.SimpleFirebaseRoot"/> class.
 		/// </summary>
 		/// <param name="_host">Host.</param>
 		/// <param name="_cred">Cred.</param>
-		public FirebaseRoot(string _host, string _cred = "")
+		public SimpleFirebaseRoot(string _host, string _cred = "")
         {
             if (firstTimeInitiated)
             {
@@ -129,7 +129,7 @@ namespace SimpleFirebaseUnity
 		/// <param name="routine">Routine.</param>
 		public void StartCoroutine(IEnumerator routine)
 		{
-			FirebaseManager.Instance.StartCoroutine (routine);
+			SimpleFirebaseManager.Instance.StartCoroutine (routine);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace SimpleFirebaseUnity
 		/// <param name="routine">Routine.</param>
 		public void StopCoroutine(IEnumerator routine)
 		{
-			FirebaseManager.Instance.StopCoroutine (routine);
+			SimpleFirebaseManager.Instance.StopCoroutine (routine);
 		}
     }
 }

--- a/SimpleFirebaseUnity/SimpleFirebaseUnity.csproj
+++ b/SimpleFirebaseUnity/SimpleFirebaseUnity.csproj
@@ -41,14 +41,14 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DataSnapshot.cs" />
-    <Compile Include="Firebase.cs" />
-    <Compile Include="FirebaseError.cs" />
-    <Compile Include="FirebaseManager.cs" />
-    <Compile Include="FirebaseObserver.cs" />
-    <Compile Include="FirebaseParam.cs" />
-    <Compile Include="FirebaseQueue.cs" />
-    <Compile Include="FirebaseRoot.cs" />
+    <Compile Include="SimpleDataSnapshot.cs" />
+    <Compile Include="SimpleFirebase.cs" />
+    <Compile Include="SimpleFirebaseError.cs" />
+    <Compile Include="SimpleFirebaseManager.cs" />
+    <Compile Include="SimpleFirebaseObserver.cs" />
+    <Compile Include="SimpleFirebaseParam.cs" />
+    <Compile Include="SimpleFirebaseQueue.cs" />
+    <Compile Include="SimpleFirebaseRoot.cs" />
     <Compile Include="miniJSON.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
fixing issue https://github.com/dkrprasetya/simple-firebase-unity/issues/10

fixed the following scenario:
- in unity:

```
using SimpleFirebaseUnity;

void Start(){
    Firebase f = Firebase.CreateNew(...);
}
```
when Google Firebase sdk is also present in the project the following error is thrown:

> error CS0118: 'Firebase' is a 'namespace' but a 'type' was expected

to fix this in this pull request I renamed all the classes in SimpleFirebaseUnity namespace with "SimpleFirebase" prefix (e.g. SimpleFirebaseError, SimpleDataSnapshot... )